### PR TITLE
CSS: stop using fake small-caps, use OpenType kerning and ligatures

### DIFF
--- a/css/archive.css
+++ b/css/archive.css
@@ -16,11 +16,14 @@ ul.post-list {
 .post-title {
   font-weight: bold;
   font-size: x-large;
-  font-variant: small-caps;
   background: none;
   margin: 0;
   padding: 0;
   display: inline-block;
+
+  -moz-font-feature-settings: "kern", "liga", "smcp";
+  -webkit-font-feature-settings: "kern", "liga", "smcp";
+  font-feature-settings: "kern", "liga", "smcp";
 }
 h2.post-title a { color: black; }
 

--- a/css/default.css
+++ b/css/default.css
@@ -104,6 +104,10 @@ body {
     margin:0px;
     font-family: "Source Serif Pro","serif";
     padding: {{page.body_padding}} 0;
+
+    -moz-font-feature-settings: "kern", "liga";
+    -webkit-font-feature-settings: "kern", "liga";
+    font-feature-settings: "kern", "liga";
 }
 
 #wrapper {
@@ -417,7 +421,9 @@ img[data-caption]:before {
 
 /* HEADINGS */
 {{ page.small_caps_headings | join: ',' }} {
-  font-variant: small-caps;
+    -moz-font-feature-settings: "kern", "liga", "smcp";
+    -webkit-font-feature-settings: "kern", "liga", "smcp";
+    font-feature-settings: "kern", "liga", "smcp";
 }
 
 {{ page.headings | join:',' }} {


### PR DESCRIPTION
Your current website is using fake, browser-generated small caps. They're too thin and weird. Let's use the small caps contained in the font.

`font-variant: small-caps` always produces fake small caps and thus is ☢, just like `letter-spacing` which is in general misused and produces bad results across the board.

I took the liberty to enable kerning and ligatures along the way, this kind of thing should really be part of the default browser stylesheets (actually, Safari does not support font-feature-settings but enables these two features by default.) 
I mentioned Safari; it won't support the OpenType small caps. If you feel like it's an important matter, the Fontsquirrel generator can unroll small caps into the base font letters, in which case you don't have to depend on OpenType support for it.

r? @huonw
