### PR TITLE
s/runtime/compile time/ typo?

### DIFF
--- a/_posts/2015-01-13-object-safety.md
+++ b/_posts/2015-01-13-object-safety.md
@@ -264,7 +264,7 @@ makes no sense.
 There's two fundamental ways in which this can happen, as an argument
 or as a return value, in either case a reference to the `Self` type
 means that it must match the type of the `self` value, the true type
-of which is unknown at runtime. For example:
+of which is unknown at compile time. For example:
 
 {% highlight rust linenos=table %}
 trait Foo {


### PR DESCRIPTION
I *think* this is what you meant. The true type of `self` is know at runtime, though the vtable.